### PR TITLE
feat: Configure Scala with Eglot and Metals LSP server

### DIFF
--- a/inits/20-company-mode.el
+++ b/inits/20-company-mode.el
@@ -13,12 +13,18 @@
   :bind
   (
    ("M-/" . company-complete)
-   ("C-<tab>" . comany-capf)
+   ("C-<tab>" . company-capf)
   )
 
   :config
   (global-company-mode) ; 全バッファで有効にする
   (company-mode 1)
+  
+  ;; Ensure company-capf is in the backends for LSP support
+  (setq company-backends
+        '((company-capf company-dabbrev-code company-keywords)
+          company-files
+          company-dabbrev))
 
   (define-key company-active-map (kbd "C-n") 'company-select-next-or-abort)
   (define-key company-active-map (kbd "C-p") 'company-select-previous-or-abort)

--- a/inits/20-eglot.el
+++ b/inits/20-eglot.el
@@ -16,7 +16,8 @@
   (setq eglot-sync-connect 5) ; Timeout for initial connection
   
   ;; Server configurations
-  (add-to-list 'eglot-server-programs '(scala-mode . ("sbt" "--client" "runMain" "org.jetbrains.sbt.ogliamo.Main"))) ; Example for Scala with Metals, adjust if needed
+  ;; Metals for Scala - using the recommended metals-emacs command
+  (add-to-list 'eglot-server-programs '(scala-mode . ("metals")))
   (add-to-list 'eglot-server-programs '(dart-mode . ("dart" "language-server" "--protocol=lsp"))) ; Example for Dart, adjust if needed
   
   :bind (:map eglot-mode-map

--- a/inits/50-scala.el
+++ b/inits/50-scala.el
@@ -1,7 +1,13 @@
 ;; Enable scala-mode and sbt-mode
 (use-package scala-mode
   :straight t
-  :mode "\\.s\\(cala\\|bt\\)$")
+  :mode "\\.s\\(cala\\|bt\\)$"
+  :hook (scala-mode . eglot-ensure)
+  :config
+  ;; Scala import indentation settings
+  (setq scala-indent:align-parameters nil
+        scala-indent:align-forms t
+        scala-indent:use-javadoc-style t))
 
 (use-package sbt-mode
   :straight t
@@ -16,3 +22,17 @@
   ;; sbt-supershell kills sbt-mode:  https://github.com/hvesalai/emacs-sbt-mode/issues/152
   (setq sbt:program-options '("-Dsbt.supershell=false"))
   )
+
+;; Optional: Add Metals-specific keybindings
+(with-eval-after-load 'scala-mode
+  (with-eval-after-load 'eglot
+    (define-key scala-mode-map (kbd "C-c m b") 'sbt-command)
+    (define-key scala-mode-map (kbd "C-c m s") 'sbt-start)
+    (define-key scala-mode-map (kbd "C-c m i") 'eglot-find-implementation)
+    (define-key scala-mode-map (kbd "C-c m t") 'eglot-find-typeDefinition)))
+
+;; Metals installation note:
+;; To install Metals, run:
+;; coursier install metals
+;; or
+;; cs install metals


### PR DESCRIPTION
Fixes #16

Configured Scala development environment with Eglot and Metals LSP server, and ensured LSP completion works with company-mode.

## Changes
- Updated scala-mode to use eglot-ensure hook
- Changed Eglot server configuration to use Metals
- Added company-capf to company-backends for LSP completion
- Fixed typo in company-mode keybinding
- Added Metals-specific keybindings for Scala development
- Added installation notes for Metals

Generated with [Claude Code](https://claude.ai/code)